### PR TITLE
chore: Standardise Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+registries:
+  python-codeartifact:
+    type: python-index
+    url: https://oaknorthbank-505282763753.d.codeartifact.eu-west-1.amazonaws.com/pypi/python-libraries/simple/
+    username: aws
+    password: ${{secrets.CODEARTIFACT_TOKEN}}
+
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "standard_change"
+    registries:
+      - python-codeartifact
+    insecure-external-code-execution: allow
+    schedule:
+      interval: daily
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 10


### PR DESCRIPTION
https://www.notion.so/Standardise-Dependabot-Configuration-3367256fbc3280a09197ceb887e6997e

## Summary

- Add dependabot.yml aligned with oaknorthbank org standard template
- Ecosystems: pip
- Schedule: daily at 09:00 Europe/London
- Stack: python-pipenv

## Context

Part of an org-wide initiative to standardise GitHub project configuration
across all oaknorthbank repositories.
